### PR TITLE
app/views/layouts: fix dustball client source link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,7 +45,7 @@
     <%= link_to 'Dustball server source', 'https://github.com/romkey/dustball-server', class: 'nav-link' %>
     </li> 
     <li class="nav-item">
-    <%= link_to 'Dustball ESP32 source', 'https://github.com/romkey/dustball-esp32', class: 'nav-link' %>
+    <%= link_to 'Dustball ESP32 source', 'https://github.com/romkey/dustball-client', class: 'nav-link' %>
     </li>
     <li class="nav-item">
     <%= link_to 'MIT License', 'https://romkey.mit-license.org', class: 'nav-link' %>


### PR DESCRIPTION
The dustball client repository appears to have been labeled dustball-esp32 at some point in the past, however clicking on the link now results in a 404